### PR TITLE
Fix/update package.json & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The reason of writing this script is that the current approach of producing HTML
 
 
 ## [Usage](id:usage)
-The script runs on top of `node.js`. The “entry point” is the `index.js` file, which accepts the following command line arguments:
+The script runs on top of `node.js`. The “entry point” is the `main.js` file, which accepts the following command line arguments:
 
 ```
 scribjs [options] [filename]
@@ -97,6 +97,6 @@ The generated minutes may be part of a page hosted by GitHub via the [Github+Jek
 
 ## Installation
 
-Standard `node.js` practices have been followed. This means that repository can be cloned and, in the directory of the repository, the `npm install` command can be used. This should create a symbolic link to `index.js` in the user’s search path with the name `scribejs`.
+Standard `node.js` practices have been followed. This means that repository can be cloned and, in the directory of the repository, the `npm install` command can be used. This should create a symbolic link to `main.js` in the user’s search path with the name `scribejs`.
 
-The repository also contains a copy of all the dependencies (i.e., the necessary node modules) in the `node_modules` directory. That means that `node index.js` (or an alias thereof) should also be functional without any further installation.
+The repository also contains a copy of all the dependencies (i.e., the necessary node modules) in the `node_modules` directory. That means that `node main` (or an alias thereof) should also be functional without any further installation.

--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
     "url": "https://github.com/w3c/scribejs/issues",
     "email": "ivan@w3.org"
   },
-  "bin": {
-    "scribejs": "./main.js"
-  },
-  "license": "W3C Software License (https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231)",
+  "bin": "./main.js",
+  "license": "W3C-20150513",
   "repository": {
     "type": "git",
     "url": "https://github.com/w3c/scribejs.git"


### PR DESCRIPTION
* `package.json`:
  * `npm` emits a warning because the licence ID isn't recognised; use the latest W3C licence from [the official list](https://spdx.org/licenses/) instead (but the warning is still there, for some reason)
  * `bin` [doesn't need to provide name of binary, as it's equal to the package's name](https://docs.npmjs.com/files/package.json#bin)
* README: main file is `main`, not `index`.