### PR TITLE
Write a test suite and set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "6"
+  - "8"
+script:
+  - npm run nsp
+  - npm test

--- a/README.md
+++ b/README.md
@@ -101,11 +101,8 @@ The generated minutes may be part of a page hosted by GitHub via the [Github+Jek
 
 Standard `node.js` practices have been followed. This means that repository can be cloned and, in the directory of the repository, the `npm install` command can be used. This should create a symbolic link to `main.js` in the user’s search path with the name `scribejs`.
 
-The repository also contains a copy of all the dependencies (i.e., the necessary node modules) in the `node_modules` directory. That means that `node main` (or an alias thereof) should also be functional without any further installation.
-
 ## Testing
 
 ```bash
 npm test
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/w3c/scribejs.svg?branch=master)](https://travis-ci.org/w3c/scribejs)
+
 # Converter of RSSAgent IRC logs into minutes in markdown
 
 This script takes an IRC output as produced by the RRSAgent on W3C’s IRC, and converts into into minutes in markdown. Most of the features of [David Booth's script](https://dev.w3.org/2002/scribe/scribedoc.htm) are retained. See also a separate [feature summary](features.md) for an easier reference. The IRC log can either be provided as an input to the script on the command line, or can be fetched directly from the W3C site. The generated minutes are either stored locally or are committed to a GitHub repository directly.
@@ -98,3 +100,12 @@ The generated minutes may be part of a page hosted by GitHub via the [Github+Jek
 ## Installation
 
 Standard `node.js` practices have been followed. This means that repository can be cloned and, in the directory of the repository, the `npm install` command can be used. This should create a symbolic link to `main.js` in the user’s search path with the name `scribejs`.
+
+The repository also contains a copy of all the dependencies (i.e., the necessary node modules) in the `node_modules` directory. That means that `node main` (or an alias thereof) should also be functional without any further installation.
+
+## Testing
+
+```bash
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribejs",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Converter of RSSAgent IRC logs into minutes in markdown",
   "main": "main.js",
   "keywords": [
@@ -50,5 +50,13 @@
     "node-fetch": "^1.7.1",
     "octokat": "^0.9.0",
     "underscore": "^1.8.3"
+  },
+  "devDependencies": {
+    "mocha": "3.4.2",
+    "nsp": "2.6.3"
+  },
+  "scripts": {
+    "nsp": "nsp check",
+    "test": "mocha"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--colors
+--growl
+--reporter spec
+--timeout 2000

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,3 +2,5 @@
 --growl
 --reporter spec
 --timeout 2000
+--use_strict
+--full-trace

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,116 @@
 'use strict';
 
-// Empty test file means okay!
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {spawn} = require('child_process');
+
+const invokeScribeJS = (params = [], handlers = null) => {
+    const fixedParams = params;
+    fixedParams.unshift('.');
+    const proc = spawn('node', fixedParams);
+    for (let event in handlers)
+        if ('data' === event) {
+            proc.stdout.on(event, handlers[event]);
+            proc.stderr.on(event, handlers[event]);
+        } else
+            proc.on(event, handlers[event]);
+};
+
+describe('Basics', () => {
+
+    describe('Node.js', () => {
+
+        it('exists', (done) => {
+            invokeScribeJS([], {exit: () => done()});
+        });
+
+    });
+
+    describe('scribejs', () => {
+
+        it('returns an error with no params', (done) => {
+            const codeChecker = (code) => {
+                assert.strictEqual(code, 255);
+                done();
+            };
+            invokeScribeJS([], {exit: codeChecker});
+        });
+
+        it('dumps help with “-h”', (done) => {
+            let output = '';
+            const outputChecker = (data) => {
+                output += data;
+            };
+            const codeChecker = (code) => {
+                assert.ok(/Usage:/.test(output));
+                assert.ok(/Options:/.test(output));
+                assert.ok(/\-\-output\ \[output\]/.test(output));
+                assert.strictEqual(code, 0);
+                done();
+            };
+            invokeScribeJS(['-h'], {data: outputChecker, exit: codeChecker});
+        });
+
+    });
+
+});
+
+describe('CLI usage', () => {
+
+    const inputFilename = path.join('test', 'dpub-test.txt');
+    const outputFilename = path.join(os.tmpdir(), `scribejs-${process.pid}.md`);
+
+    it('can read log from a local file', (done) => {
+        let output = '';
+        const outputChecker = (data) => {
+            output += data;
+        };
+        const codeChecker = (code) => {
+            assert.ok(/^\!\[W3C\ Logo\]\(https:\/\/www\.w3\.org\/Icons\/w3c_home\)/.test(output));
+            assert.ok(/^#\s.+\s—\sMinutes$/m.test(output));
+            assert.strictEqual(code, 0);
+            done();
+        };
+        invokeScribeJS([inputFilename], {data: outputChecker, exit: codeChecker});
+    });
+
+    it('can dump result to a local file', (done) => {
+        const resultChecker = (code) => {
+            assert.strictEqual(code, 0);
+            fs.access(outputFilename, fs.constants.F_OK | fs.constants.R_OK, (err) => {
+                if (err)
+                    done(err);
+                else
+                    fs.readFile(outputFilename, (err, data) => {
+                        if (err)
+                            done(err);
+                        fs.unlink(outputFilename, (err) => {
+                            if (err)
+                                done(err);
+                        });
+                        assert.ok(/^\!\[W3C\ Logo\]\(https:\/\/www\.w3\.org\/Icons\/w3c_home\)/.test(data));
+                        assert.ok(/^#\s.+\s—\sMinutes$/m.test(data));
+                        done();
+                    });
+            });
+        };
+        invokeScribeJS(['-o', outputFilename, inputFilename], {exit: resultChecker});
+    });
+
+    // [TODO]
+
+});
+
+describe('CGI usage', () => {
+
+    // [TODO]
+
+});
+
+describe('Web interface', () => {
+
+    // [TODO]
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,3 @@
+'use strict';
+
+// Empty test file means okay!


### PR DESCRIPTION
`test/test.js` is a test suite to be run with [Mocha](https://mochajs.org/) (added as a `devDependency`): it checks a few simple things (Node.js is present, invoking scribejs w/o params produces an error), and then tests the CLI in a couple scenarios (local log file, local output).

It's a beginning. Some important bugs will be captured by this test suite as it is now (some JS syntax errors; some missing packages; some uncaught exceptions; some errors reading a local log, producing Markdown, or dumping the result to a local file, etc). But more comprehensive testing is desirable; eg, uploading to GH, testing as a CGI script, etc. See comments `[TODO]` at the end of the file.

Output example:

```
$ npm test

> scribejs@0.10.0 test /home/travis/build/w3c/scribejs
> mocha

  Basics
    Node.js
      ✓ exists (166ms)
    scribejs
      ✓ returns an error with no params (159ms)
      ✓ dumps help with “-h” (144ms)

  CLI usage
    ✓ can read log from a local file (278ms)
    ✓ can dump result to a local file (256ms)

  5 passing (1s)
```

[Travis CI is set up](https://travis-ci.org/w3c/scribejs) and doing builds now with versions of Node.js 6 and 8. New branches and PRs will be tested automatically.

The Travis script, `.travis.yml`, also invokes `nsp` to check for known vulnerabilities in the versions of npm packages we're using (`nsp` added as a `devDependency`).

README updated.

Fixes #8.