### PR TITLE
Improvements on the change requests with s/.../.../ syntax

### DIFF
--- a/features.md
+++ b/features.md
@@ -65,10 +65,10 @@ The roles are as follows:
 ## Change of the IRC lines
 
 * `s/from/to/` or `s|from|to|`
-	* change, in the generated minutes, the _closest previous_ appearance of `from` to `to`. `from` and `to` are regular strings, not regular expressions
+	* change, in the generated minutes, all occurences of the string `from` to `to` in the _closest preceding_ line with a match. `from` and `to` are regular strings, not regular expressions.
 * `s/from/to/g` or `s|from|to|g`
-	* like a simple change except that *all* previous appearances of `from` are changed to `to`
+	* like a simple change except that *all* previous lines are handled.
 * `s/from/to/G` or `s|from|to|G`
-	* change *all* appearances of `from` to `to` in the minutes
+	* change *all* appearances of `from` to `to` in the minutes.
 * `i/at/add/` or `i|at|add|`
-	* look for the _closest previous_ appearance of `at` and insert a *new line* with the value of `add` as a content *before* the line. A typical usage is to add a (sub)topic line that was forgotten (or because the discussion took an unexpected turn).
+	* look for the _closest preceding_ line matching `at` and insert a *new line* with the value of `add` as a content *before* that line. A typical usage is to add a (sub)topic line that was forgotten or because the discussion took an unexpected turn.


### PR DESCRIPTION
* the regexp was too restrictive and did not work for patterns with dots
* the order of invalidating a request created a problem in some edge cases (if the same pattern appeared before and after the s/../../ line
* use a regexp in the `replace` function to ensure that all occurrences are changed
* improved the text of the corresponding documentation