### PR TITLE
Guest handling improvements

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -224,7 +224,8 @@ exports.to_markdown = (body, config) => {
 				   line_object.content_lower.startsWith("agenda?")   ||
 				   line_object.content_lower.startsWith("trackbot,") ||
 				   line_object.content_lower.startsWith("zakim,")    ||
-				   line_object.content_lower.startsWith("rrsagent,")
+				   line_object.content_lower.startsWith("rrsagent,") ||
+				   line_object.content_lower.startsWith("github-bot,")
 			   )
 		   })
 		   .filter((line_object) => (line_object.content.match(/^\w+ has joined #\w+/) === null))

--- a/convert.js
+++ b/convert.js
@@ -277,6 +277,11 @@ exports.to_markdown = (body, config) => {
 		 */
 		// Care should be taken to trim everything, to keep the nick names clean of extra spaces...
 		function people(category, line) {
+			// A frequent mistake is to use "guest" instead of "guests", or "regret" instead of "regrets".
+			// Although the "official" documented version is the plural form, I decided to make
+			// the script resilient...
+			let real_category = (category === "guest") ? "guests" : ((category === "regret") ? "regrets" : category)
+
 			let get_names = (index) => {
 				let retval = line.content.slice(index+1).trim().split(',');
 				if(retval.length === 0 || (retval.length === 1 && retval[0].length === 0)) {
@@ -315,7 +320,7 @@ exports.to_markdown = (body, config) => {
 					// This is not a correct usage...
 					return false;
 				}
-				headers[category] = action(headers[category], _.map(names, (name) => name.trim()))
+				headers[real_category] = action(headers[real_category], _.map(names, (name) => name.trim()))
 				return true;
 			} else {
 				return false;
@@ -361,7 +366,9 @@ exports.to_markdown = (body, config) => {
 		let processed_lines = _.chain(lines)
 			.filter((line) => !people("present", line))
 			.filter((line) => !people("regrets", line))
+			.filter((line) => !people("regret", line))
 			.filter((line) => !people("guests", line))
+			.filter((line) => !people("guest", line))
 			.filter((line) => !people("chair", line))
 			.filter((line) => !single_item("agenda", line))
 			.filter((line) => !single_item("meeting", line))

--- a/convert.js
+++ b/convert.js
@@ -171,6 +171,7 @@ exports.to_markdown = (body, config) => {
 	 *  - remove zakim agenda control commands
 	 *  - remove bot commands ("zakim,", "rrsagent,", etc.)
 	 *  - remove the "XXX has joined #YYY" type messages
+	 *  - handle the "scribejs, nick FULL NAME" type commands
 	 *
 	 * The incoming body is either a single string with many lines (this is the case when the script is invoked from the
      * command line) or already split into individual lines (this is the case when the data comes via the CGI interface).
@@ -229,6 +230,36 @@ exports.to_markdown = (body, config) => {
 		   .filter((line_object) => (line_object.content.match(/^\w+ has joined #\w+/) === null))
 		   .filter((line_object) => (line_object.content.match(/^\w+ has left #\w+/) === null))
 		   .filter((line_object) => (line_object.content.match(/^\w+ has changed the topic to:/) === null))
+		   .filter((line_object) => {
+				// Handle the "scribejs, XXX" command
+				// At the moment, there is only one XXX tool, namely 'set', so the handling is put into one function.
+				// If, in future, other scribejs commands are introduced, then this function may become a bit more complicated
+				// The effect is to extend the configuration's nickname object.   
+			   	if(line_object.content_lower.startsWith("scribejs, set")) {
+					let words = line_object.content.split(" ");
+					try {
+						// If there is a problem somewhere, it should simply be forgotten
+						// this is a beautifying step, ie, an exception could be forgotten
+						let nickname   = words[2].toLowerCase();
+						let name_comps = words.slice(3);
+						if(name_comps.length !== 0) {
+							// note that the nickname assignment during the call has a higher priority than
+							// what comes from the external file, ie, it is silently overwritten
+							// The name is cleared from the '_' signs, which are usually used to replace spaces...
+							// let name = name_comps.join(" ").replace(/_/g, ' ');
+							config.nick_mappings[nickname] = { nick: [nickname], name: name_comps.join(" ").replace(/_/g, ' ') }		
+						} 
+					} catch(err) {
+						; // console.log(err)
+					} finally {
+						// returning 'false' will remove this line from the result
+						return false					
+					}
+			   	} else {
+					// This line should remain for further processing
+				   	return true
+			   	}
+		   })
 		   // End of the underscore chain, retrieve the final value
 		   .value();
 	};

--- a/features.md
+++ b/features.md
@@ -2,7 +2,7 @@
 
 This document describe the features that can/should be used for the purpose of scribing using the W3C IRC Server. The features handled by this converter are essentially the same as [David Booth's script](https://dev.w3.org/2002/scribe/scribedoc.htm), although there some minor additions.
 
-The script removes all lines referring to queue control, as well as commands referring to the `RSSAgent` or `trackbot` IRC bots.
+The script removes all lines referring to queue control, as well as commands referring to the `RSSAgent`, `zakim`, `trackbot`, and `github-bot` IRC bots.
 
 Most IRC commands are based on a `ROLE: value` pattern, where the various “roles” are described below. The roles are case _insensitive_. For some roles, the syntax `ROLE+ value` or `ROLE- value` may also be used with a slightly different meaning. Some of the roles have aliases.
 

--- a/features.md
+++ b/features.md
@@ -4,7 +4,9 @@ This document describe the features that can/should be used for the purpose of s
 
 The script removes all lines referring to queue control, as well as commands referring to the `RSSAgent` or `trackbot` IRC bots.
 
-The IRC commands are based on a `ROLE: value` pattern, where the various “roles” are described below. The roles are case _insensitive_. For some roles, the syntax `ROLE+ value` or `ROLE- value` may also be used with a slightly different meaning. Some of the roles have aliases.
+Most IRC commands are based on a `ROLE: value` pattern, where the various “roles” are described below. The roles are case _insensitive_. For some roles, the syntax `ROLE+ value` or `ROLE- value` may also be used with a slightly different meaning. Some of the roles have aliases.
+
+There are also some (currently only one) `scribejs` “tools” that influence the operation of `scribejs`. These begin by the `scribejs, XXX` string and a space, and are followed by the command itself, where `XXX` is the tool identifier.
 
 When referring to names (e.g., `scribenick`, `present`, scribe’s reference to speaker, etc.) the preferred way is to use that person’s IRC nickname. If done that way (and if a suitable configuration file is provided) the script would automatically convert those into the persons’ real name, which make the minutes more readable.
 
@@ -72,3 +74,10 @@ The roles are as follows:
 	* change *all* appearances of `from` to `to` in the minutes.
 * `i/at/add/` or `i|at|add|`
 	* look for the _closest preceding_ line matching `at` and insert a *new line* with the value of `add` as a content *before* that line. A typical usage is to add a (sub)topic line that was forgotten or because the discussion took an unexpected turn.
+
+## `Scribejs` Tools
+
+The line starting with `scribejs, XXX [ARGS]` is a `scribejs` tool, where `XXX` is the tool identifier, and the arguments depend on the tool identifier itself. `XXX` may be
+
+* `scribejs, set [nickname] [full name]`
+	* Set the (IRC) `nickname` to refer to the full name in the generated minutes. `full name` is space or underscore separated list of words (underscores are converted to spaces). Its use is to provide a one-time extension to the nickname mappings, see [README.md](#nick). 

--- a/test/guest.test
+++ b/test/guest.test
@@ -19,8 +19,10 @@
 16:06:02 <ivan> regrets+ garth
 16:06:14 <NickRuffilo> jyasskin: I am here...
 16:06:14 <ivan> guests+ Jeffrey_Yasskin
+16:06:14 <ivan> scribejs, set jyasskin Prof. Dr. Jeffrey_Yasskin, Jr.
 16:07:44 <dauwhe> Web packaging explainer https://github.com/WICG/webpackage/blob/master/explainer.md
 16:07:57 <NickRuffilo> Garth: Tzviya is opt to point out, we've spent much time on the first working draft on Web Publications, if you looked at the schedule, we should have the first working draft of the PORTABLE web publication in TPAC time.  I've asked a colleague of mine from Google who has been doing work on the web packaging arena - which is a candidate technology - as we look at what packages look like.  I'm introducing Jeffrey Yasskin - who's been working on search front end, ..., he's also chaired web-front end group, which lead to working on the chrome platform team...  He's just done alot of stuff, so with that, I'd like to have Jeff do an introduction and talk about history and where web packaging is now.
 16:08:14 <NickRuffilo> ... where the constituent pieces are being developed, open up to Q&A then move to next topics.
 16:09:29 <NickRuffilo> jyasskin: I've been working on packaging since the beginning of the year.  The project came out of our emerging markets - a system might have an expensive or limited data plan - so there is peer-to-peer data sharing.  Our team wanted to share web pages in the same way.  We're using MHTML as a stop=gap.  MHTML is for a single page, not a web-app.  Then I came along and took over the standards effort for that.
+16:09:29 <NickRuffilo> ... with some additional remarks after the continuation signs
 16:09:32 <jyasskin> https://github.com/WICG/webpackage

--- a/test/guest.test
+++ b/test/guest.test
@@ -1,0 +1,26 @@
+15:49:40 <RRSAgent> RRSAgent has joined #pwg
+15:49:40 <RRSAgent> logging to http://www.w3.org/2017/09/11-pwg-irc
+15:49:41 <ivan> rrsagent, set log public
+15:49:41 <ivan> Meeting: Publishing Working Group Telco
+15:49:41 <ivan> Chair: Garth
+15:49:41 <ivan> Date: 2017-09-11
+15:49:41 <ivan> Agenda: https://lists.w3.org/Archives/Public/public-publ-wg/2017Sep/0017.html
+15:49:42 <ivan> ivan has changed the topic to: Meeting Agenda 2017-09-11: https://lists.w3.org/Archives/Public/public-publ-wg/2017Sep/0017.html
+15:56:00 <ivan> present+
+15:56:32 <tzviya> present+
+15:58:57 <NickRuffilo> scribenick: NickRuffilo
+15:59:19 <ivan> present+ NickRuffilo
+16:00:22 <mattg> present+
+16:02:36 <ivan> guests+ Ralph_Swick
+16:05:25 <ivan> present+ garth
+16:06:00 <ivan> guest+ Wendy_Seltzer
+16:06:02 <garth> present+ Garth
+16:06:02 <ivan> regret+ timCole
+16:06:02 <ivan> regrets+ garth
+16:06:14 <NickRuffilo> jyasskin: I am here...
+16:06:14 <ivan> guests+ Jeffrey_Yasskin
+16:07:44 <dauwhe> Web packaging explainer https://github.com/WICG/webpackage/blob/master/explainer.md
+16:07:57 <NickRuffilo> Garth: Tzviya is opt to point out, we've spent much time on the first working draft on Web Publications, if you looked at the schedule, we should have the first working draft of the PORTABLE web publication in TPAC time.  I've asked a colleague of mine from Google who has been doing work on the web packaging arena - which is a candidate technology - as we look at what packages look like.  I'm introducing Jeffrey Yasskin - who's been working on search front end, ..., he's also chaired web-front end group, which lead to working on the chrome platform team...  He's just done alot of stuff, so with that, I'd like to have Jeff do an introduction and talk about history and where web packaging is now.
+16:08:14 <NickRuffilo> ... where the constituent pieces are being developed, open up to Q&A then move to next topics.
+16:09:29 <NickRuffilo> jyasskin: I've been working on packaging since the beginning of the year.  The project came out of our emerging markets - a system might have an expensive or limited data plan - so there is peer-to-peer data sharing.  Our team wanted to share web pages in the same way.  We're using MHTML as a stop=gap.  MHTML is for a single page, not a web-app.  Then I came along and took over the standards effort for that.
+16:09:32 <jyasskin> https://github.com/WICG/webpackage

--- a/test/guest.test
+++ b/test/guest.test
@@ -25,4 +25,5 @@
 16:08:14 <NickRuffilo> ... where the constituent pieces are being developed, open up to Q&A then move to next topics.
 16:09:29 <NickRuffilo> jyasskin: I've been working on packaging since the beginning of the year.  The project came out of our emerging markets - a system might have an expensive or limited data plan - so there is peer-to-peer data sharing.  Our team wanted to share web pages in the same way.  We're using MHTML as a stop=gap.  MHTML is for a single page, not a web-app.  Then I came along and took over the standards effort for that.
 16:09:29 <NickRuffilo> ... with some additional remarks after the continuation signs
+16:09:30 <NickRuffilo> github-bot, end topic
 16:09:32 <jyasskin> https://github.com/WICG/webpackage


### PR DESCRIPTION
- Accept 'guest' and not only 'guests' as commands
- Possibility to add session-only nickname mapping (typically used for guests)
- Remove `github-bot` commands (o.k., this is not related to guests...)