### PR TITLE
Turn off build notifications by e-mail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "6"
   - "8"
+notifications:
+  email: false
 script:
   - npm run nsp
   - npm test


### PR DESCRIPTION
Travis is sending me mail when build statuses change after my commits/PRs. I don't know about others, but I look at build statuses on PRs directly, and use web notifications instead. I don't like the extra noise of mail.

This disables [mail notifications](https://docs.travis-ci.com/user/notifications#Configuring-email-notifications) altogether. If other contributors like them, I can instead list their individual addresses on the Travis config file (and not include mine).