### PR TITLE
Remove --growl from mocha.opts; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,10 @@ The `schemas` directory also includes two [JSON schemas](http://json-schema.org/
 ```bash
 npm test
 ```
+
+If you have [Growl](https://github.com/tj/node-growl#installation) setup for
+your platform, you can use it like so:
+
+```bash
+npm test -- --growl
+```

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --colors
---growl
 --reporter spec
 --timeout 2000
 --use_strict


### PR DESCRIPTION
You can still optionally use it (see the README).