### PR TITLE
Correct eslint max-len config

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,7 +13,9 @@ rules: # see https://eslint.org/docs/rules/
     no-console: off
     camelcase: off
     strict: off
-    max-len: 120
+    max-len:
+        - error
+        - code: 120
     key-spacing:
         - error
         - align:


### PR DESCRIPTION
Makes this value work when linting.

See https://eslint.org/docs/rules/max-len for more.