### PR TITLE
Unbreak CI

### DIFF
--- a/src/lib/conf.ts
+++ b/src/lib/conf.ts
@@ -41,7 +41,7 @@ const default_config: Global = {
 * @returns the parsed JSON content
 * @throws - either not-found error, or schema validation errors
 */
-function json_conf_file(file_name: string, group: string, local: boolean, warn: boolean = true): Configuration {
+function json_conf_file(file_name: string, group: string, local: boolean): Configuration {
     let file_c = null;
     try {
         file_c = fs.readFileSync(file_name, 'utf-8');


### PR DESCRIPTION
Without this change, `npm run lint` fails with the following error:

> /home/travis/build/w3c/scribejs/src/lib/conf.ts
> 44:75  error  Type boolean trivially inferred from a boolean literal, remove type annotation  @typescript-eslint/no-inferrable-types